### PR TITLE
Using process.exit to close the process at the end

### DIFF
--- a/bin/attester-launcher
+++ b/bin/attester-launcher
@@ -23,12 +23,13 @@ if (controller) {
                 controller.stop();
             }
         });
-        controller.on("exit", function () {
-            process.disconnect();
-        });
     }
+
     process.on("SIGINT", function() {
         controller.stop();
+    });
+    controller.on("exit", function () {
+        process.exit();
     });
 
     if (process.platform === "win32") {
@@ -38,12 +39,6 @@ if (controller) {
         });
         readline.on("SIGINT", function () {
             process.emit("SIGINT");
-        });
-        controller.on("exit", function () {
-            if (readline) {
-                readline.close();
-                readline = null;
-            }
         });
     }
 }


### PR DESCRIPTION
This commit forces the process to exit at the end instead of relying on the
absence of any scheduled work for the event loop.