### PR TITLE
Disabling the promise manager in webdriver launcher

### DIFF
--- a/src/launchers/webdriver.js
+++ b/src/launchers/webdriver.js
@@ -19,6 +19,8 @@ var util = require("util");
 var events = require("events");
 var mapToJson = require("../util/mapToJson");
 
+webdriver.promise.USE_PROMISE_MANAGER = false;
+
 var WebdriverLauncher = module.exports = function() {};
 
 util.inherits(WebdriverLauncher, events.EventEmitter);


### PR DESCRIPTION
The promise manager can make the whole process crash by throwing an uncaught
exception in some cases:
https://github.com/SeleniumHQ/selenium/blob/selenium-3.6.0/javascript/node/selenium-webdriver/lib/promise.js#L2626

Disabling the promise manager prevents this dangerous code from being used. In case of an error, only the promise returned by webdriver for the corresponding browser is rejected. attester-launcher can then try to restart the browser.